### PR TITLE
Fixed #12 - timeStart and timeEnd Variables are Scanning Incorrectly

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,35 +6,49 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 )
 
+func exeTime(name string) func() {
+	start := time.Now()
+	return func() {
+		fmt.Printf("%s execution time: %v\n", name, time.Since(start))
+	}
+}
+
 func main() {
+
+	defer exeTime("main")()
+
 	var month, day, year, radar string
-	var timeStart, timeEnd int
+	var timeStart, timeEnd string
 
 	fmt.Print("Enter Month: ")
 	fmt.Scanln(&month)
-	// fmt.Println("d3 =", month)
 
 	fmt.Print("Enter Day: ")
 	fmt.Scanln(&day)
-	// fmt.Println("d3 =", day)
 
 	fmt.Print("Enter Year: ")
 	fmt.Scanln(&year)
-	// fmt.Println("d3 =", year)
 
 	fmt.Print("Enter Radar: ")
 	fmt.Scanln(&radar)
-	// fmt.Println("d3 =", timeNow)
 
 	fmt.Print("Time Start in Zulu (HHMMSS): ")
 	fmt.Scanln(&timeStart)
+	// Fixed octal issue by dereferencing the pointer and converting to integer from string that is passed to the CLI
+	test := *&timeStart
+	test1, _ := strconv.Atoi(test)
 
 	fmt.Print("Time End in Zulu (HHMMSS): ")
 	fmt.Scanln(&timeEnd)
+	test3 := *&timeEnd
+	test4, _ := strconv.Atoi(test3)
 
-	for x := timeStart; x <= timeEnd; x++ {
+	for x := test1; x <= test4; x++ {
+
 		timeComb := fmt.Sprintf("%06d", x)
 
 		url := fmt.Sprintf("https://noaa-nexrad-level2.s3.amazonaws.com/%s/%s/%s/%s/%s%s%s%s_%s_V06", year, month, day, radar, radar, year, month, day, timeComb)
@@ -46,13 +60,17 @@ func main() {
 
 		resp, err := http.Get(url)
 		if err == nil && resp.StatusCode == 200 {
-			fmt.Println("Fetching", url)
+			fmt.Println("(+) FETCHING", url)
 			body, _ := io.ReadAll(resp.Body)
 			filePath := filepath.Join(folderLocation, fmt.Sprintf("%s_%s_%s_%s_%s", day, month, year, radar, timeComb))
 			os.WriteFile(filePath, body, 0644)
 		}
 
-		if x == timeEnd {
+		if err == nil && resp.StatusCode != 200 {
+			fmt.Println("(-) CANNOT FETCH", url, resp.StatusCode)
+		}
+
+		if x == test4 {
 			fmt.Println("Done...")
 			return
 		}


### PR DESCRIPTION
Issue with int literal being passed as a octal. Solved by passing the response as a string first, dereferencing the pointer, and then converting to a integer
